### PR TITLE
Fix issue with Alt Button hiding follows

### DIFF
--- a/twitter-alt-text-viewer.user.css
+++ b/twitter-alt-text-viewer.user.css
@@ -82,7 +82,7 @@ and replacing all instances of "Image" in this userstyle with that.
     /* also hide twitter's self-alt icon. */
     /* this rule is a little clumsy and might hide other parts of the UI too. */
     /* I'd like to find a better way to do this. */
-    div[aria-describedby^="id__"][role="button"] {
+    [data-testid="tweet"] div[aria-describedby^="id__"][role="button"] {
         display: none;
     }
 


### PR DESCRIPTION
Follow button got updated and the run to hide the alt button now hides it as well. 

updated the rule to only hide the role=button inside the "testid="tweet" divs